### PR TITLE
Add the ability to override the colour for a specific path

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,9 +2,17 @@
 
 const hashbow = require('hashbow');
 
+function getOverrides(path) {
+  return window.config.getConfig()['hyperterm-dibdabs'].overrides[path];
+}
+
+function getColor(path) {
+  return getOverrides(path) || hashbow(path);
+}
+
 exports.getTabProps = function (uid, parentProps, props) {
   return Object.assign({}, props, {
-    dabColor: hashbow(props.text)
+    dabColor: getColor(props.text)
   });
 };
 

--- a/readme.md
+++ b/readme.md
@@ -8,3 +8,20 @@ my dotfiles are always that same pink and my home folder always that same blue.
 Makes moving between projects that little bit quicker.
 
 Powered by [hashbow](https://www.npmjs.com/package/hashbow)
+
+## Config
+To override the color of your dibdab, add the file path and desired color (hex or rgb) to the `override` attribute of the plugin's configuration, located in the `hyper.js` file.
+
+**For example:** Update the color of the `Development` directory to a lovely pale green.
+
+``` javascript
+module.exports = {
+  config: {
+    'hyperterm-dibdabs': {
+      overrides: {
+        '~/Development': '#c0ffee'
+      }
+    }
+  }
+}
+```


### PR DESCRIPTION
- Allows you to override the color of a directory :) 
- Updates the readme with some instructions

My development directory is now a soothing pale green colour to calm me down while I work.

<img width="501" alt="screen shot 2017-11-17 at 2 56 46 pm" src="https://user-images.githubusercontent.com/3030010/32928716-97998628-cba7-11e7-8b77-81dee2aaf317.png">

resolves: #2 

@supercrabtree 